### PR TITLE
Add "requireConfigFile": false on parserOptions

### DIFF
--- a/09-managing-state-in-class-components/.eslintrc.json
+++ b/09-managing-state-in-class-components/.eslintrc.json
@@ -14,6 +14,7 @@
   "plugins": ["react", "import", "jsx-a11y"],
   "parser": "@babel/eslint-parser",
   "parserOptions": {
+    "requireConfigFile": false,
     "ecmaVersion": 2020,
     "sourceType": "module",
     "ecmaFeatures": {


### PR DESCRIPTION
Added requireConfigFile: false to fix babel error with react-router-dom. Fixes issue #6